### PR TITLE
Add support for "overblog/dataloader-php" data loaders

### DIFF
--- a/conf/services.yaml
+++ b/conf/services.yaml
@@ -5,13 +5,15 @@ services:
     public: true
   OmegaCode\JwtSecuredApiGraphQL\:
     resource: '../src/*'
-    exclude: '../src/{GraphQL},Kernel.php'
+    exclude: '../src/{GraphQL,Event},Kernel.php'
 
   OmegaCode\JwtSecuredApiGraphQL\Action\GraphQL\IndexAction:
     arguments:
       $container: '@service_container'
 
-  OmegaCode\JwtSecuredApiGraphQL\GraphQL\ResolverRegistry:
+  OmegaCode\JwtSecuredApiGraphQL\GraphQL\Registry\ResolverRegistry:
+
+  OmegaCode\JwtSecuredApiGraphQL\GraphQL\Registry\DataLoaderRegistry:
 
   OmegaCode\JwtSecuredApiGraphQL\Command\ClearCacheCommand:
     decorates: 'OmegaCode\JwtSecuredApiCore\Command\ClearCacheCommand'

--- a/src/Event/DataLoaderCollectedEvent.php
+++ b/src/Event/DataLoaderCollectedEvent.php
@@ -26,47 +26,37 @@
 
 declare(strict_types=1);
 
-namespace OmegaCode\JwtSecuredApiGraphQL\GraphQL;
+namespace OmegaCode\JwtSecuredApiGraphQL\Event;
 
 use OmegaCode\JwtSecuredApiGraphQL\GraphQL\Registry\DataLoaderRegistry;
-use Psr\Container\ContainerInterface;
-use Psr\Http\Message\RequestInterface;
+use Overblog\PromiseAdapter\PromiseAdapterInterface;
+use Symfony\Contracts\EventDispatcher\Event;
 
-class Context
+class DataLoaderCollectedEvent extends Event
 {
-    protected ContainerInterface $container;
+    public const NAME = 'graphql.data_loader_registry.collected';
 
-    protected RequestInterface $request;
+    protected DataLoaderRegistry $registry;
 
-    protected DataLoaderRegistry $dataLoaderRegistry;
+    protected PromiseAdapterInterface $promiseAdapter;
 
-    public function getContainer(): ContainerInterface
+    public function __construct(DataLoaderRegistry $registry)
     {
-        return $this->container;
+        $this->registry = $registry;
     }
 
-    public function setContainer(ContainerInterface $container): void
+    public function getRegistry(): DataLoaderRegistry
     {
-        $this->container = $container;
+        return $this->registry;
     }
 
-    public function getRequest(): RequestInterface
+    public function setPromiseAdapter(PromiseAdapterInterface $promiseAdapter): void
     {
-        return $this->request;
+        $this->promiseAdapter = $promiseAdapter;
     }
 
-    public function setRequest(RequestInterface $request): void
+    public function getPromiseAdapter(): PromiseAdapterInterface
     {
-        $this->request = $request;
-    }
-
-    public function getDataLoaderRegistry(): DataLoaderRegistry
-    {
-        return $this->dataLoaderRegistry;
-    }
-
-    public function setDataLoaderRegistry(DataLoaderRegistry $dataLoaderRegistry): void
-    {
-        $this->dataLoaderRegistry = $dataLoaderRegistry;
+        return $this->promiseAdapter;
     }
 }

--- a/src/Event/ResolverCollectedEvent.php
+++ b/src/Event/ResolverCollectedEvent.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace OmegaCode\JwtSecuredApiGraphQL\Event;
 
-use OmegaCode\JwtSecuredApiGraphQL\GraphQL\ResolverRegistry;
+use OmegaCode\JwtSecuredApiGraphQL\GraphQL\Registry\ResolverRegistry;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class ResolverCollectedEvent extends Event

--- a/src/GraphQL/DataLoader/DataLoaderBuilderInterface.php
+++ b/src/GraphQL/DataLoader/DataLoaderBuilderInterface.php
@@ -26,47 +26,12 @@
 
 declare(strict_types=1);
 
-namespace OmegaCode\JwtSecuredApiGraphQL\GraphQL;
+namespace OmegaCode\JwtSecuredApiGraphQL\GraphQL\DataLoader;
 
-use OmegaCode\JwtSecuredApiGraphQL\GraphQL\Registry\DataLoaderRegistry;
-use Psr\Container\ContainerInterface;
-use Psr\Http\Message\RequestInterface;
+use Overblog\DataLoader\DataLoader;
+use Overblog\PromiseAdapter\PromiseAdapterInterface;
 
-class Context
+interface DataLoaderBuilderInterface
 {
-    protected ContainerInterface $container;
-
-    protected RequestInterface $request;
-
-    protected DataLoaderRegistry $dataLoaderRegistry;
-
-    public function getContainer(): ContainerInterface
-    {
-        return $this->container;
-    }
-
-    public function setContainer(ContainerInterface $container): void
-    {
-        $this->container = $container;
-    }
-
-    public function getRequest(): RequestInterface
-    {
-        return $this->request;
-    }
-
-    public function setRequest(RequestInterface $request): void
-    {
-        $this->request = $request;
-    }
-
-    public function getDataLoaderRegistry(): DataLoaderRegistry
-    {
-        return $this->dataLoaderRegistry;
-    }
-
-    public function setDataLoaderRegistry(DataLoaderRegistry $dataLoaderRegistry): void
-    {
-        $this->dataLoaderRegistry = $dataLoaderRegistry;
-    }
+    public static function build(PromiseAdapterInterface $promiseAdapter): DataLoader;
 }

--- a/src/GraphQL/Provider/SchemaProvider.php
+++ b/src/GraphQL/Provider/SchemaProvider.php
@@ -34,7 +34,7 @@ use GraphQL\Language\Parser;
 use GraphQL\Type\Schema;
 use GraphQL\Utils\AST;
 use GraphQL\Utils\BuildSchema;
-use OmegaCode\JwtSecuredApiGraphQL\GraphQL\ResolverRegistry;
+use OmegaCode\JwtSecuredApiGraphQL\GraphQL\Registry\ResolverRegistry;
 
 class SchemaProvider implements SchemaProviderInterface
 {
@@ -76,10 +76,10 @@ class SchemaProvider implements SchemaProviderInterface
         $resolverRegistry = $this->resolverRegistry;
         $typeConfigDecorator = function (&$typeConfig) use ($resolverRegistry) {
             $type = $typeConfig['name'];
-            if (!$resolverRegistry->hasResolverForType($type)) {
+            if (!$resolverRegistry->has($type)) {
                 return $typeConfig;
             }
-            $resolver = $resolverRegistry->getResolverByType($type);
+            $resolver = $resolverRegistry->get($type);
             $typeConfig['resolveField'] = $resolver;
 
             return $typeConfig;

--- a/src/GraphQL/Registry/DataLoaderRegistry.php
+++ b/src/GraphQL/Registry/DataLoaderRegistry.php
@@ -26,47 +26,16 @@
 
 declare(strict_types=1);
 
-namespace OmegaCode\JwtSecuredApiGraphQL\GraphQL;
+namespace OmegaCode\JwtSecuredApiGraphQL\GraphQL\Registry;
 
-use OmegaCode\JwtSecuredApiGraphQL\GraphQL\Registry\DataLoaderRegistry;
-use Psr\Container\ContainerInterface;
-use Psr\Http\Message\RequestInterface;
+use Overblog\DataLoader\DataLoader;
 
-class Context
+class DataLoaderRegistry extends AbstractRegistry
 {
-    protected ContainerInterface $container;
+    public const TYPE = DataLoader::class;
 
-    protected RequestInterface $request;
-
-    protected DataLoaderRegistry $dataLoaderRegistry;
-
-    public function getContainer(): ContainerInterface
+    public function __construct()
     {
-        return $this->container;
-    }
-
-    public function setContainer(ContainerInterface $container): void
-    {
-        $this->container = $container;
-    }
-
-    public function getRequest(): RequestInterface
-    {
-        return $this->request;
-    }
-
-    public function setRequest(RequestInterface $request): void
-    {
-        $this->request = $request;
-    }
-
-    public function getDataLoaderRegistry(): DataLoaderRegistry
-    {
-        return $this->dataLoaderRegistry;
-    }
-
-    public function setDataLoaderRegistry(DataLoaderRegistry $dataLoaderRegistry): void
-    {
-        $this->dataLoaderRegistry = $dataLoaderRegistry;
+        parent::__construct(self::TYPE);
     }
 }

--- a/src/GraphQL/Registry/ResolverRegistry.php
+++ b/src/GraphQL/Registry/ResolverRegistry.php
@@ -26,47 +26,31 @@
 
 declare(strict_types=1);
 
-namespace OmegaCode\JwtSecuredApiGraphQL\GraphQL;
+namespace OmegaCode\JwtSecuredApiGraphQL\GraphQL\Registry;
 
-use OmegaCode\JwtSecuredApiGraphQL\GraphQL\Registry\DataLoaderRegistry;
-use Psr\Container\ContainerInterface;
-use Psr\Http\Message\RequestInterface;
+use InvalidArgumentException;
+use OmegaCode\JwtSecuredApiGraphQL\GraphQL\Resolver\ResolverInterface;
 
-class Context
+class ResolverRegistry extends AbstractRegistry
 {
-    protected ContainerInterface $container;
+    public const TYPE = ResolverInterface::class;
 
-    protected RequestInterface $request;
-
-    protected DataLoaderRegistry $dataLoaderRegistry;
-
-    public function getContainer(): ContainerInterface
+    public function __construct()
     {
-        return $this->container;
+        parent::__construct(self::TYPE);
     }
 
-    public function setContainer(ContainerInterface $container): void
+    /**
+     * @param ResolverInterface $item
+     */
+    public function add($item, string $key): void
     {
-        $this->container = $container;
-    }
-
-    public function getRequest(): RequestInterface
-    {
-        return $this->request;
-    }
-
-    public function setRequest(RequestInterface $request): void
-    {
-        $this->request = $request;
-    }
-
-    public function getDataLoaderRegistry(): DataLoaderRegistry
-    {
-        return $this->dataLoaderRegistry;
-    }
-
-    public function setDataLoaderRegistry(DataLoaderRegistry $dataLoaderRegistry): void
-    {
-        $this->dataLoaderRegistry = $dataLoaderRegistry;
+        if (empty($item->getType())) {
+            throw new InvalidArgumentException('Method getType of given resolver can not be empty!');
+        }
+        if (!is_callable($item)) {
+            throw new InvalidArgumentException('The given resolver ' . $item->getType() . ' is not callable! Add method __invoke to the resolver');
+        }
+        parent::add($item, $key);
     }
 }

--- a/src/GraphQL/Resolver/QueryResolver.php
+++ b/src/GraphQL/Resolver/QueryResolver.php
@@ -33,10 +33,7 @@ use OmegaCode\JwtSecuredApiGraphQL\GraphQL\Context;
 
 class QueryResolver implements ResolverInterface
 {
-    /**
-     * @param mixed $root
-     */
-    public function __invoke($root, array $args, Context $context, ResolveInfo $info): ?string
+    public function __invoke($root, array $args, Context $context, ResolveInfo $info)
     {
         if ($info->fieldName === 'greet') {
             $name = strip_tags($args['name']);

--- a/src/GraphQL/Resolver/ResolverInterface.php
+++ b/src/GraphQL/Resolver/ResolverInterface.php
@@ -28,7 +28,17 @@ declare(strict_types=1);
 
 namespace OmegaCode\JwtSecuredApiGraphQL\GraphQL\Resolver;
 
+use GraphQL\Type\Definition\ResolveInfo;
+use OmegaCode\JwtSecuredApiGraphQL\GraphQL\Context;
+
 interface ResolverInterface
 {
+    /**
+     * @param mixed $parent
+     *
+     * @return mixed
+     */
+    public function __invoke($parent, array $args, Context $context, ResolveInfo $info);
+
     public function getType(): string;
 }

--- a/src/Middleware/SchemaResolverInjectionMiddleware.php
+++ b/src/Middleware/SchemaResolverInjectionMiddleware.php
@@ -29,8 +29,8 @@ declare(strict_types=1);
 namespace OmegaCode\JwtSecuredApiGraphQL\Middleware;
 
 use OmegaCode\JwtSecuredApiGraphQL\Event\ResolverCollectedEvent;
+use OmegaCode\JwtSecuredApiGraphQL\GraphQL\Registry\ResolverRegistry;
 use OmegaCode\JwtSecuredApiGraphQL\GraphQL\Resolver\QueryResolver;
-use OmegaCode\JwtSecuredApiGraphQL\GraphQL\ResolverRegistry;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -51,7 +51,7 @@ class SchemaResolverInjectionMiddleware implements \Psr\Http\Server\MiddlewareIn
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $queryResolver = new QueryResolver();
-        $this->resolverRegistry->addResolver($queryResolver);
+        $this->resolverRegistry->add($queryResolver, $queryResolver->getType());
         $this->eventDispatcher->dispatch(
             new ResolverCollectedEvent($this->resolverRegistry),
             ResolverCollectedEvent::NAME


### PR DESCRIPTION
Added:
- DataLoaderRegistry to store DataLoader instances
- namespace Event to exclude of auto wiring.
- new event ot collect DataLoader instances.
- DataLoaderRegistry as new property on the Context object.
- interface to create DataLoader instances.
- AbstractRegistry class to create registry classes.

Update:
- ResolverRegistry to use the AbstractRegistry.
- SchemaProvider to fit the new ResolverRegistry API.
- SchemaResolverInjectionMiddleware to fit the new ResolverRegistry API.
- ResolverInterface to include __invoke in the API.